### PR TITLE
Required DI version should be 2.6 or grater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.5",
         "aws/aws-sdk-php": "^3.2.4",
         "symfony/config": "~2.3",
-        "symfony/dependency-injection": "~2.3",
+        "symfony/dependency-injection": "~2.6",
         "symfony/http-kernel": "~2.3"
     },
     "require-dev": {


### PR DESCRIPTION
The minimum required version of `symfony/dependency-injection` is 2.6.

This is because the incorporation of `Definition::setFactory`.

In Symfony 2.5 or lower fails with:

    PHP Fatal error:  Call to undefined method Symfony\Component\DependencyInjection\Definition::setFactory() in /srv/www/vendor/aws/aws-sdk-php-symfony/src/DependencyInjection/AwsExtension.php on line 53