### PR TITLE
Fix deprecated messages

### DIFF
--- a/src/DependencyInjection/AwsExtension.php
+++ b/src/DependencyInjection/AwsExtension.php
@@ -50,9 +50,17 @@ class AwsExtension extends Extension
             class_exists($clientClass) ? $clientClass : AwsClient::class
         );
 
-        $serviceDefinition
-            ->setFactoryService('aws_sdk')
-            ->setFactoryMethod('create' . $name);
+        // Handle Symfony >= 2.6
+        if (method_exists($serviceDefinition, 'setFactory')) {
+            $serviceDefinition->setFactory([
+                new Reference('aws_sdk'),
+                'create' . $name,
+            ]);
+        } else {
+            $serviceDefinition
+                ->setFactoryService('aws_sdk')
+                ->setFactoryMethod('create' . $name);
+        }
 
         return $serviceDefinition;
     }


### PR DESCRIPTION
I know this was in a previous release. But was taken out to support version 2.3. Added check for the new method introduced 2.6. To remove over 200 deprecation message I was seeing in my 2.7 installation.