### PR TITLE
Fix command for listing AWS services

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The services made available depends on which version of the SDK is installed. To
 view a full list, run the following command from your application's root 
 directory:
 ```
-php app/console container:debug | grep aws
+php app/console debug:container | grep aws
 ```
 
 Full documentation on each of the services listed can be found in the [SDK API 


### PR DESCRIPTION
The Symfony console component changed the command "php app/console container:debug" to "php app/console debug:container" - the former does not work on current Symfony versions anymore.