### PR TITLE
Fix deprecation notice in yaml file on symfony 3.1+

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -3,6 +3,6 @@ parameters:
 
 services:
     aws_sdk:
-        class: %aws_sdk.class%
+        class: "%aws_sdk.class%"
         arguments:
             - ~


### PR DESCRIPTION
Symfony 3.1+ deprecates yaml scalars starting with `%` (see [1](https://github.com/symfony/yaml/blob/master/CHANGELOG.md), [2](https://github.com/symfony/symfony/blob/master/UPGRADE-3.1.md)) which now have to be quoted.

This fix should make it work on 3.1+ without triggering a deprecation notice and should also work on older versions.