### PR TITLE
Create aliases for "aws.*" services into their fully qualified namespace.

### DIFF
--- a/src/DependencyInjection/AwsExtension.php
+++ b/src/DependencyInjection/AwsExtension.php
@@ -39,6 +39,9 @@ class AwsExtension extends Extension
                 'aws.' . strtolower($awsService),
                 $this->createServiceDefinition($awsService)
             );
+            
+            // Handle Symfony >= 3.3
+            $container->setAlias("Aws\\{$awsService}\\{$awsService}Client", 'aws.' . strtolower($awsService));
         }
     }
 


### PR DESCRIPTION
Possible fix for issue: #26

To remove deprecation notices from Symfony 3.3 about autowiring services based on the types they implement. For example:

Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "aws.dynamodb" service to "Aws\DynamoDb\DynamoDbClient" instead.

Here, I create aliases for each service. I suspect there's a neater way of handling this, but this seemed to work OK in my test setup.