### PR TITLE
Prepare to support Symfony Flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "aws/aws-sdk-php-symfony",
     "description": "A Symfony bundle for v3 of the AWS SDK for PHP",
     "keywords": [ "aws", "amazon", "symfony", "symfony2", "symfony3", "sdk"],
+    "type": "symfony-bundle",
     "minimum-stability": "stable",
     "license": "Apache-2.0",
     "authors": [


### PR DESCRIPTION
Dear guys,

From Symfony version 3.3 there is new way of building Symfony apps, that's Symfony Flex. It requires the type of package should be "symfony-bundle", but "library".

For your information, I created a receipt to work with your bundle at:
https://github.com/symfony/recipes-contrib/pull/120

The conversation here:
https://github.com/symfony/flex/issues/193

Please help me review this PR.

Regards.
 
