### PR TITLE
Avoid deprecated notice when using symfony/config > 4.2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -10,8 +10,12 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder;
-        $treeBuilder->root('aws', 'variable');
+        $treeBuilder = new TreeBuilder('aws', 'variable');
+
+        // Keep compatibility with symfony/config < 4.2
+        if (!method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->root('aws', 'variable');
+        }
 
         return $treeBuilder;
     }


### PR DESCRIPTION
See: https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config