### PR TITLE
add optional config merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ class AppKernel extends Kernel
 
 ## Configuration
 
-Configuration is handled by the SDK rather than by the bundle, and no validation
-is performed at compile time. Full documentation of the configuration options
-available can be read in the [SDK Guide](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html).
+By default, configuration is handled by the SDK rather than by the bundle, and
+no validation is performed at compile time. Full documentation of the
+configuration options available can be read in the [SDK Guide](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html).
+
+If AWS_MERGE_CONFIG environment variable is set to `true`, configuration
+validation and merging are enabled. The bundle validates and merges known
+configuration options, including for each service.  Additional configuration
+options can be included in a single configuration file, but merging will fail
+if non-standard options are specified in more than once.
 
 To use a service for any configuration value, use `@` followed by the service
 name, such as `@a_service`. This syntax will be converted to a service during

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -10,12 +10,103 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
+        // Maintain backwars compatibility, only merge when AWS_MERGE_CONFIG is set
+        $mergeConfig = getenv('AWS_MERGE_CONFIG') ?: false;
+        $treeType = 'variable';
+
+        if ($mergeConfig) {
+            $treeType = 'array';
+        }
+
         // Most recent versions of TreeBuilder have a constructor
         if (\method_exists(TreeBuilder::class, '__construct')) {
-            $treeBuilder = new TreeBuilder('aws', 'variable');
+            $treeBuilder = new TreeBuilder('aws', $treeType);
         } else { // which is not the case for older versions
             $treeBuilder = new TreeBuilder;
-            $treeBuilder->root('aws', 'variable');
+            $treeBuilder->root('aws', $treeType);
+        }
+
+        // If not AWS_MERGE_CONFIG, return empty, variable TreeBuilder
+        if (!$mergeConfig) {
+            return $treeBuilder;
+        }
+
+        // Define TreeBuilder to allow config validation and merging
+        $treeBuilder->getRootNode()
+            ->ignoreExtraKeys(false)
+            ->children()
+                ->variableNode('credentials')->end()
+                ->variableNode('debug')->end()
+                ->variableNode('stats')->end()
+                ->scalarNode('endpoint')->end()
+                ->variableNode('endpoint_discovery')->end()
+                ->arrayNode('http')
+                    ->children()
+                        ->floatNode('connect_timeout')->end()
+                        ->booleanNode('debug')->end()
+                        ->booleanNode('decode_content')->end()
+                        ->integerNode('delay')->end()
+                        ->variableNode('expect')->end()
+                        ->variableNode('proxy')->end()
+                        ->scalarNode('sink')->end()
+                        ->booleanNode('synchronous')->end()
+                        ->booleanNode('stream')->end()
+                        ->floatNode('timeout')->end()
+                        ->scalarNode('verify')->end()
+                    ->end()
+                ->end()
+                ->scalarNode('profile')->end()
+                ->scalarNode('region')->end()
+                ->integerNode('retries')->end()
+                ->scalarNode('scheme')->end()
+                ->scalarNode('service')->end()
+                ->scalarNode('signature_version')->end()
+                ->variableNode('ua_append')->end()
+                ->variableNode('validate')->end()
+                ->scalarNode('version')->end()
+            ->end()
+        ;
+
+        //Setup config trees for each of the services
+        foreach (array_column(Aws\manifest(), 'namespace') as $awsService) {
+            $treeBuilder->getRootNode()
+                ->children()
+                    ->arrayNode($awsService)
+                        ->ignoreExtraKeys(false)
+                        ->children()
+                            ->variableNode('credentials')->end()
+                            ->variableNode('debug')->end()
+                            ->variableNode('stats')->end()
+                            ->scalarNode('endpoint')->end()
+                            ->variableNode('endpoint_discovery')->end()
+                            ->arrayNode('http')
+                                ->children()
+                                    ->floatNode('connect_timeout')->end()
+                                    ->booleanNode('debug')->end()
+                                    ->booleanNode('decode_content')->end()
+                                    ->integerNode('delay')->end()
+                                    ->variableNode('expect')->end()
+                                    ->variableNode('proxy')->end()
+                                    ->scalarNode('sink')->end()
+                                    ->booleanNode('synchronous')->end()
+                                    ->booleanNode('stream')->end()
+                                    ->floatNode('timeout')->end()
+                                    ->scalarNode('verify')->end()
+                                ->end()
+                            ->end()
+                            ->scalarNode('profile')->end()
+                            ->scalarNode('region')->end()
+                            ->integerNode('retries')->end()
+                            ->scalarNode('scheme')->end()
+                            ->scalarNode('service')->end()
+                            ->scalarNode('signature_version')->end()
+                            ->variableNode('ua_append')->end()
+                            ->variableNode('validate')->end()
+                            ->scalarNode('version')->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
         }
 
         return $treeBuilder;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,8 +31,10 @@ class Configuration implements ConfigurationInterface
             return $treeBuilder;
         }
 
+        $rootNode = $treeBuilder->root('aws');
+
         // Define TreeBuilder to allow config validation and merging
-        $treeBuilder->getRootNode()
+        $rootNode
             ->ignoreExtraKeys(false)
             ->children()
                 ->variableNode('credentials')->end()
@@ -69,7 +71,7 @@ class Configuration implements ConfigurationInterface
 
         //Setup config trees for each of the services
         foreach (array_column(Aws\manifest(), 'namespace') as $awsService) {
-            $treeBuilder->getRootNode()
+            $rootNode
                 ->children()
                     ->arrayNode($awsService)
                         ->ignoreExtraKeys(false)


### PR DESCRIPTION
Resolves https://github.com/aws/aws-sdk-php-symfony/issues/51

Optional configuration validation and merging via AWS_MERGE_CONFIG env variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
