### PR TITLE
Mark s3 client service definition as lazy

### DIFF
--- a/src/DependencyInjection/AwsExtension.php
+++ b/src/DependencyInjection/AwsExtension.php
@@ -60,6 +60,7 @@ class AwsExtension extends Extension
         }
 
         return $serviceDefinition
+                ->setLazy(true)
                 ->setFactoryService('aws_sdk')
                 ->setFactoryMethod('create' . $name);
     }


### PR DESCRIPTION
Instantiating a client has a big memory cost, because it loads a big
JSON file (https://github.com/aws/aws-sdk-php/blob/master/src/data/s3/2006-03-01/api-2.json)

Closes #59


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
