### PR TITLE
Avoid calling magic methods to support linting the DIC

### DIFF
--- a/src/DependencyInjection/AwsExtension.php
+++ b/src/DependencyInjection/AwsExtension.php
@@ -55,14 +55,15 @@ class AwsExtension extends Extension
         if (method_exists($serviceDefinition, 'setFactory')) {
             return $serviceDefinition->setFactory([
                 new Reference('aws_sdk'),
-                'create' . $name,
-            ]);
+                'createClient',
+            ])->setArguments([$name]);
         }
 
         return $serviceDefinition
                 ->setLazy(true)
                 ->setFactoryService('aws_sdk')
-                ->setFactoryMethod('create' . $name);
+                ->setFactoryMethod('createClient')
+                ->setArguments([$name]);
     }
 
     private function inflateServicesInConfig(array &$config)


### PR DESCRIPTION
Symfony 4.4 added a `lint:container` command. This linting step fails for the `aws.*` services created on the fly by this bundle, because those calls will in fact be handled by a magic method:


https://github.com/aws/aws-sdk-php/blob/02131fd17c9b62f36993bb2da88dd624ce058179/src/Sdk.php#L476-L478

By calling the `createClient` method directly, we can avoid these errors.

<hr>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
