### PR TITLE
Favor TreeBuilder::getRootNode

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,10 +31,10 @@ class Configuration implements ConfigurationInterface
             return $treeBuilder;
         }
 
-        if (method_exists($treeBuilder, 'root')) {
-            $rootNode = $treeBuilder->root('aws');
-        } else {
+        if (method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('aws', $treeType);
         }
 
         // Define TreeBuilder to allow config validation and merging


### PR DESCRIPTION
*Description of changes:*

So the bundle doesn't produce notices about `root` being deprecated.

Also changed the call to `root` so it passes `treeType` as it does a few
lines up. Seems like calling `root` replaces the root node so the
AWS_MERGE_CONFIG thing might have been subtlely broken in older symfony
versions?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
