### PR TITLE
Mark client as lazy for all Symfony versions

### DIFF
--- a/src/DependencyInjection/AwsExtension.php
+++ b/src/DependencyInjection/AwsExtension.php
@@ -51,6 +51,8 @@ class AwsExtension extends Extension
             class_exists($clientClass) ? $clientClass : AwsClient::class
         );
 
+        $serviceDefinition->setLazy(true);
+
         // Handle Symfony >= 2.6
         if (method_exists($serviceDefinition, 'setFactory')) {
             return $serviceDefinition->setFactory([
@@ -60,7 +62,6 @@ class AwsExtension extends Extension
         }
 
         return $serviceDefinition
-                ->setLazy(true)
                 ->setFactoryService('aws_sdk')
                 ->setFactoryMethod('createClient')
                 ->setArguments([$name]);


### PR DESCRIPTION
The previous fix only impacted Symfony < 2.6.

*Issue #, if available:* none

*Description of changes:*

In #60 , I made the S3Client lazy, or so I thought, but it turns out this only applies to a code path I'm no longer interested in. In fact, I don't really think I was using such an ancient version at the time so I don't know what happened.

Anyway, making the S3Client lazy is important because it does expensive stuff in its constructor, like loading a huge php file.

![2022-02-03_10-58](https://user-images.githubusercontent.com/657779/152320616-19fac59a-672d-4c16-a737-10cd803327a9.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
