### PR TITLE
Use $_ENV instead getenv for dotenv overloading

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -11,7 +11,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         // Maintain backwars compatibility, only merge when AWS_MERGE_CONFIG is set
-        $mergeConfig = getenv('AWS_MERGE_CONFIG') ?: false;
+        $mergeConfig = isset($_ENV['AWS_MERGE_CONFIG'])? $_ENV['AWS_MERGE_CONFIG'] : false;
         $treeType = 'variable';
 
         if ($mergeConfig) {


### PR DESCRIPTION
Fix bug with dotenv overloading.
In prod environment, getenv does not reach the overloaded values with dotenv

{"message":"Failed to generate ConfigBuilder for extension Aws\\Symfony\\DependencyInjection\\AwsExtension.","context":{"exception":{"class":"LogicException","message":"The node was expected to be an ArrayNode. This Configuration includes an edge case not supported yet.","code":0,"file":"/var/www/service/vendor/symfony/config/Builder/ConfigBuilderGenerator.php:103"},"extensionClass":"Aws\\Symfony\\DependencyInjection\\AwsExtension"},"level":300,"level_name":"WARNING","channel":"app","datetime":"2022-03-18T13:00:00.153193+00:00","extra":{}}
