### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 .* export-ignore
 *.md export-ignore
-tests export-ignore
+tests/ export-ignore
 phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.* export-ignore
+*.md export-ignore
+tests export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Hi @stobrien89, the gitattributes file with the `export-ignore` option allow to not export some files when creating a release.
This way people which are installing this release won't have those files, this is for instance useful for the test folder ; when installing a library we don't need your tests.

I saw you have one in another repo (https://github.com/aws/aws-sdk-php/blob/master/.gitattributes) but there is none here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
