### PR TITLE
Specify in PHPDoc the return type of Configuration::getConfigTreeBuilder

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,6 +8,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         // Maintain backwars compatibility, only merge when AWS_MERGE_CONFIG is set


### PR DESCRIPTION
*Issue #, if available:*
Resolves #88

*Description of changes:*
Added the return type of `TreeBuilder` to the `Configuration::getConfigTreeBuilder` to avoid the following Deprecation notice:

```
Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Aws\Symfony\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
