### PR TITLE
Kaznovac yamless

### DIFF
--- a/src/DependencyInjection/AwsExtension.php
+++ b/src/DependencyInjection/AwsExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -17,11 +17,11 @@ class AwsExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new YamlFileLoader(
+        $loader = new XmlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../Resources/config')
         );
-        $loader->load('services.yml');
+        $loader->load('services.xml');
 
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="aws_sdk.class">Aws\Sdk</parameter>
+    </parameters>
+
+    <services>
+        <service id="aws_sdk" class="%aws_sdk.class%">
+            <argument/>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,8 +1,0 @@
-parameters:
-    aws_sdk.class: Aws\Sdk
-
-services:
-    aws_sdk:
-        class: "%aws_sdk.class%"
-        arguments:
-            - ~


### PR DESCRIPTION
*Issue #, if available:* #91
Fixes #91 

*Description of changes:*
change services di configuration to use the xml instead of yaml
it's the symfony way... for example see doctrine bundle https://github.com/doctrine/DoctrineBundle/tree/2.10.x/Resources/config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
