### PR TITLE
chore: update test's workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       #for each of the following versions of PHP, with and without --prefer-lowest
       matrix:
-        php-versions: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
-
+        php-versions: [ '7.2.5', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        composer-options: [ '', '--prefer-lowest' ]
     #set the name for each job
     name: PHP ${{ matrix.php-versions }}
     steps:
@@ -36,3 +36,13 @@ jobs:
       #run tests
       - name: Run test suite
         run: vendor/bin/phpunit
+
+      #php 8.x requirements
+      - if: ${{ matrix.php-versions >= '8.0' && matrix.composer-options != '' }}
+        name: PHP 8.x
+        run: composer require --dev phpunit/phpunit "^9.5" --no-interaction --prefer-source --with-all-dependencies
+
+      #php 8.1+ requirements
+      - if: ${{ matrix.php-versions >= '8.1' && matrix.composer-options != '' }}
+        name: PHP 8.1+
+        run: composer require --dev guzzlehttp/guzzle "^7.4.5" --no-interaction --prefer-source --with-all-dependencies


### PR DESCRIPTION
In order to deprecate versions of PHP below than 7.2.5 then, we need to make our workflow for tests checks to just run those tests against PHP versions equals or greater than 7.2.5, and that is what this change is meant for.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
